### PR TITLE
Configurable PKCE flag for confidential clients

### DIFF
--- a/src/Fido2me/Data/OIDC/OidcBasicClient.cs
+++ b/src/Fido2me/Data/OIDC/OidcBasicClient.cs
@@ -45,6 +45,9 @@ namespace Fido2me.Data.OIDC
         public bool AllowOfflineAccess { get; set; }
 
         [Required]
+        public bool RequirePkce { get; set; }
+
+        [Required]
         public DateTimeOffset Created { get; set; }
 
         public DateTimeOffset? Updated { get; set; }

--- a/src/Fido2me/Data/OIDC/OidcPersistedGrant.cs
+++ b/src/Fido2me/Data/OIDC/OidcPersistedGrant.cs
@@ -13,5 +13,6 @@ namespace Fido2me.Data.OIDC
         public DateTime CreationTime { get; set; }
         public DateTime? Expiration { get; set; }
         public string Data { get; set; }
+        public DateTimeOffset? ConsumedAt { get; set; }
     }
 }

--- a/src/Fido2me/Data/OidcExtenstions.cs
+++ b/src/Fido2me/Data/OidcExtenstions.cs
@@ -16,7 +16,9 @@ namespace Fido2me.Data
                 ClientSecrets = oidcc.ClientSecrets.Select(c => new Secret { Type = c.Type, Value = c.Value, Description = c.Description, Expiration = c.Expiration?.UtcDateTime }).ToList(),
                 AllowedScopes = oidcc.ClientScopes,
                 AllowedCorsOrigins = oidcc.ClientCorsOrigins,
-                RedirectUris = oidcc.ClientRedirectUris,               
+                RedirectUris = oidcc.ClientRedirectUris, 
+                AllowPlainTextPkce = false,
+                RequirePkce = oidcc.RequirePkce,
             };
             return ic;
         }
@@ -44,6 +46,7 @@ namespace Fido2me.Data
                 RequireConsent = ic.RequireConsent,
                 Updated = created, //TODO
                 LogoUri = ic.LogoUri,
+                RequirePkce = ic.RequirePkce,
             };
             return oidc;
         }

--- a/src/Fido2me/Duende/PersistedGrantStore.cs
+++ b/src/Fido2me/Duende/PersistedGrantStore.cs
@@ -27,7 +27,7 @@ namespace Fido2me.Duende
         {
             var pGrant = await _dataContext.OidcPersistedGrants
                                 .AsNoTracking()
-                                .Where(g => g.Key == key)
+                                .Where(g => g.Key == key && g.ConsumedAt == null)
                                 .Select(g => new PersistedGrant()
                                 {
                                     Key = g.Key,
@@ -45,14 +45,15 @@ namespace Fido2me.Duende
 
         public Task RemoveAllAsync(PersistedGrantFilter filter)
         {
-            return Task.CompletedTask;
-           
+            return Task.CompletedTask;           
         }
 
-        public Task RemoveAsync(string key)
+        public async Task RemoveAsync(string key)
         {
-            return Task.CompletedTask;
-        
+            var grant = await _dataContext.OidcPersistedGrants.Where(g => g.Key == key && g.ConsumedAt == null).FirstOrDefaultAsync();
+            grant.ConsumedAt = DateTimeOffset.UtcNow;
+
+            await _dataContext.SaveChangesAsync();        
         }
 
         public async Task StoreAsync(PersistedGrant grant)

--- a/src/Fido2me/Models/Applications/OidcClientEditViewModel.cs
+++ b/src/Fido2me/Models/Applications/OidcClientEditViewModel.cs
@@ -15,6 +15,8 @@ namespace Fido2me.Models.Applications
 
         public string[] Scopes { get; set; }
 
+        public bool RequirePkce { get; set; } = true;
+
         [Required]
         [MaxLength(200)]
         public string Name { get; set; }

--- a/src/Fido2me/Models/Applications/OidcCreateClientViewModel.cs
+++ b/src/Fido2me/Models/Applications/OidcCreateClientViewModel.cs
@@ -23,6 +23,8 @@ namespace Fido2me.Models.Applications
         [Required]
         public bool RequireClientSecret { get; set; } = true;
 
+        public bool RequirePkce { get; set; } = true;
+
         //public bool? RequireConsent { get; set; }
 
         //public bool? AllowRememberConsent { get; set; }

--- a/src/Fido2me/Pages/apps/Create.cshtml
+++ b/src/Fido2me/Pages/apps/Create.cshtml
@@ -27,13 +27,18 @@
                 <div class="form-group form-check col-md-3">
                     <label class="form-check-label  ms-3">
                         <input class="form-check-input" asp-for="OidcCreateClientViewModel.RequireClientSecret" />
-                        <b>Can use Secret</b>
+                        <b>Can use Secret. </b>
                     </label>
                 </div>
                 <div class="col-md">
                     Select, if your client is confidential.
-                    <p>Confidential clients are applications that are able to securely authenticate with the authorization server, for example being able to keep their registered client secret safe.</p>
-                    <p>Public clients are unable to use registered client secrets, such as applications running in a browser or on a mobile device.</p>
+                    <a class="" data-bs-toggle="collapse" data-bs-target="#requireSecret" href="#requireSecret">
+                        More...
+                    </a>                
+                    <div class="col-md collapse" id="requireSecret" >                    
+                        <p>Confidential clients are applications that are able to securely authenticate with the authorization server, for example being able to keep their registered client secret safe.</p>
+                        <p>Public clients are unable to use registered client secrets, such as applications running in a browser or on a mobile device.</p>
+                    </div>
                 </div>
             </div>
 
@@ -44,7 +49,6 @@
                     <i class="bi bi-clipboard"></i>
                 </button>
            </div>
-
             <div class="input-group mb-3">
                 <span class="input-group-text fw-bold w-25">Client Secret</span>
                 <input class="form-control" readonly  asp-for="OidcCreateClientViewModel.ClientSecret" />
@@ -55,7 +59,14 @@
             <div class="alert alert-info" role="alert">
                 Copy your secret now. You won’t be able to see it again.
             </div>
-
+            <div class="row g-3">
+                <div class="form-group form-check col-md-3">
+                    <label class="form-check-label  ms-3">
+                        <input class="form-check-input" asp-for="OidcCreateClientViewModel.RequirePkce" />
+                        Proof Key (PKCE)
+                    </label>
+                </div>
+            </div>
             <div class="form-group">
                 <label class="control-label ms-3 fw-bold w-25" for="scopes">Scopes</label>
 

--- a/src/Fido2me/Pages/apps/Edit.cshtml
+++ b/src/Fido2me/Pages/apps/Edit.cshtml
@@ -36,37 +36,47 @@
                 <span class="input-group-text fw-bold w-25">Type</span>
                 <input type="text" class="form-control" asp-for="OidcClientEdit.Type" disabled>
             </div>
+            @{
+                string pkceEnabled = Model.OidcClientEdit.Type == "Public" ? "hidden" : "";
+            }
+            <div class="row g-3" id="divPkce" @pkceEnabled>
+                <div class="form-group form-check col-md-3">
+                    <label class="form-check-label ms-3">
+                        <input class="form-check-input" type="checkbox" asp-for="OidcClientEdit.RequirePkce" />
+                        Proof Key (PKCE)
+                        </label>
+                    </div>
+                </div>
+                <div class="input-group mb-3">
+                    <span class="input-group-text fw-bold w-25">Scope</span>
+                    <input type="text" class="form-control" asp-for="OidcClientEdit.Scope" disabled>
+                </div>
 
-            <div class="input-group mb-3">
-                <span class="input-group-text fw-bold w-25">Scope</span>
-                <input type="text" class="form-control" asp-for="OidcClientEdit.Scope" disabled>
-            </div>
+
+                <div class="input-group mb-3">
+                    <span class="input-group-text fw-bold w-25">Callback URL</span>
+                    <input type="text" class="form-control" placeholder="https:/MyAppDomain.com/signin-oidc" asp-for="OidcClientEdit.RedirectUri" required />
+                </div>
+
+                <div class="input-group mb-3">
+                    <span class="input-group-text fw-bold w-25">Allowed Origin</span>
+                    <input type="text" class="form-control" placeholder="https:/MyAppDomain.com/signin-oidc" asp-for="OidcClientEdit.CorsOrigin" />
+                </div>
 
 
-            <div class="input-group mb-3">
-                <span class="input-group-text fw-bold w-25">Callback URL</span>
-                <input type="text" class="form-control" placeholder="https:/MyAppDomain.com/signin-oidc" asp-for="OidcClientEdit.RedirectUri" required />
-            </div>
-
-            <div class="input-group mb-3">
-                <span class="input-group-text fw-bold w-25">Allowed Origin</span>
-                <input type="text" class="form-control" placeholder="https:/MyAppDomain.com/signin-oidc" asp-for="OidcClientEdit.CorsOrigin" />
-            </div>
-
-
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
-            </div>
-        </form>
+                <div class="form-group">
+                    <input type="submit" value="Save" class="btn btn-primary" />
+                </div>
+            </form>
+        </div>
     </div>
-</div>
 
 
 
-<div>
-    <a asp-page="./Index">Back to List</a>
-</div>
+    <div>
+        <a asp-page="./Index">Back to List</a>
+    </div>
 
-@section Scripts {
-    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
-}
+    @section Scripts {
+        @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    }

--- a/src/Fido2me/Services/OidcBasicClientService.cs
+++ b/src/Fido2me/Services/OidcBasicClientService.cs
@@ -119,13 +119,14 @@ namespace Fido2me.Services
             {
                 return false;
             }
-            var requirePkce = client.RequireClientSecret ? client.RequirePkce : true;
+            var requirePkce = client.RequireClientSecret ? oidcClientEdit.RequirePkce : true;
             client.Updated = DateTimeOffset.UtcNow;
             client.ClientName = oidcClientEdit.Name;
             client.Description = oidcClientEdit.Description;
             client.ClientRedirectUris = new string[] { oidcClientEdit.RedirectUri };
             client.Enabled = oidcClientEdit.Enabled;
             client.ClientCorsOrigins = new string[] { oidcClientEdit.CorsOrigin };
+            client.RequirePkce = requirePkce;
 
             await _context.SaveChangesAsync();
 


### PR DESCRIPTION
Adding PKCE flag for OIDC client. Allow to use it only for Confidential clients.

Use case: Some services don't support PKCE but assume it's okay to not use it for confidential client flow.