### PR TITLE
Do not validate issuer and endpoints for CIBA

### DIFF
--- a/src/Fido2me/Services/DiscoveryService.cs
+++ b/src/Fido2me/Services/DiscoveryService.cs
@@ -18,8 +18,15 @@ namespace Fido2me.Services
         {
             _logger = logger;
             var discoEndpoint = configuration["oidc:discoEndpoint"] ?? throw new ArgumentNullException(nameof(IConfiguration));
-            
-            _cache = new DiscoveryCache(discoEndpoint);
+
+            // oidc:discoEndpoint is localhost, not fido2me.com
+            // have to use localhost for now to reach .well-known/openid-configuration endpoint from a container
+            var discoveryPolicy = new DiscoveryPolicy()
+            { 
+                ValidateIssuerName = false,
+                ValidateEndpoints = false,
+            };
+            _cache = new DiscoveryCache(discoEndpoint, discoveryPolicy);            
         }
 
         public async Task<string> GetCibaEndpointAsync()


### PR DESCRIPTION
`oidc:discoEndpoint`  is localhost, not fido2me.com.
we have to use localhost, for now, to reach `.well-known/openid-configuration` endpoint from a container.
Need a better solution in the future.